### PR TITLE
Fix random selection bias

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -20,17 +20,21 @@ export function getRandomUniqueElements<T>(arr: T[], count: number): T[] {
     console.error("getRandomUniqueElements: count must be a non-negative number", count);
     return [];
   }
+  const pool = [...arr];
 
-  if (count > arr.length) {
-    // If requesting more elements than available, return a shuffled copy of the original array.
-    // Or, one might choose to throw an error or return only arr.length elements.
-    // For this game, returning all available (shuffled) seems reasonable.
-    console.warn(
-      `getRandomUniqueElements: Requested ${count} elements, but array only has ${arr.length}. Returning all elements shuffled.`
-    );
-    return [...arr].sort(() => 0.5 - Math.random());
+  // Shuffle using Fisher-Yates for unbiased random order.
+  for (let i = pool.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [pool[i], pool[j]] = [pool[j], pool[i]];
   }
 
-  const shuffled = [...arr].sort(() => 0.5 - Math.random());
-  return shuffled.slice(0, count);
+  if (count > pool.length) {
+    // If requesting more elements than available, return the full shuffled array.
+    console.warn(
+      `getRandomUniqueElements: Requested ${count} elements, but array only has ${pool.length}. Returning all elements shuffled.`
+    );
+    return pool;
+  }
+
+  return pool.slice(0, count);
 }


### PR DESCRIPTION
## Summary
- use unbiased Fisher-Yates shuffle in `getRandomUniqueElements`

## Testing
- `npm run lint` *(fails: requires interactive ESLint configuration)*
- `npm run typecheck` *(fails: GenerateImage type overload and multiple TS2322 errors)*

------
https://chatgpt.com/codex/tasks/task_e_689c2c50be848326a75fa15222d01b46